### PR TITLE
Disable default features for libgssapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ document-features = { version = "0.2.5", optional = true }
 serde = { version = "1", optional = true, default_features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1", optional = true, default_features = false, features = ["alloc"] }
 
-libgssapi = { version = "0.6", optional = true }
+libgssapi = { version = "0.6", optional = true, default_features = false }
 bitflags = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Resolves #29 

I'm not sure if the `oiv` and `localname` are needed for the purposes of this library. If so maybe could add a new flag so that they can be optional included. It seems there's no support for building libgssapi on macs without excluding the default features: https://github.com/estokes/libgssapi/issues/2