### PR TITLE
docs: Document features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ static_assertions = "1.1.0"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "client_simple"

--- a/bin/interop-client/src/main.rs
+++ b/bin/interop-client/src/main.rs
@@ -117,14 +117,17 @@ impl TypedValueParser for UrlParser {
     }
 }
 
-fn connect<S: AsRef<str>>(host: url::Host<S>, port: u16) -> miette::Result<(Box<dyn io::BufRead>, Box<dyn io::Write>)> {
+fn connect<S: AsRef<str>>(
+    host: url::Host<S>,
+    port: u16,
+) -> miette::Result<(Box<dyn io::BufRead>, Box<dyn io::Write>)> {
     let stream = match host {
         Host::Ipv4(ip) => TcpStream::connect((ip, port)),
         Host::Ipv6(ip) => TcpStream::connect((ip, port)),
         Host::Domain(ref domain) => TcpStream::connect((domain.as_ref(), port)),
     }
-        .into_diagnostic()
-        .wrap_err(format!("failed to connect to {}:{}", host, port))?;
+    .into_diagnostic()
+    .wrap_err(format!("failed to connect to {}:{}", host, port))?;
 
     let write_end = stream
         .try_clone()
@@ -169,32 +172,31 @@ pub fn main() -> miette::Result<()> {
         .into_diagnostic()
         .wrap_err("Failed to start client session")?;
 
-    let (mut rx, mut tx): (Box<dyn io::BufRead>, Box<dyn io::Write>) = match matches.get_one::<Either<url::Url, UrlStdin>>("listen") {
-        Some(Either::Left(url)) => { 
-            let host = url.host().ok_or_else(|| miette!("URL must have a host part"))?;
-            let port = url.port().unwrap_or(62185);
+    let (mut rx, mut tx): (Box<dyn io::BufRead>, Box<dyn io::Write>) =
+        match matches.get_one::<Either<url::Url, UrlStdin>>("listen") {
+            Some(Either::Left(url)) => {
+                let host = url
+                    .host()
+                    .ok_or_else(|| miette!("URL must have a host part"))?;
+                let port = url.port().unwrap_or(62185);
 
-            connect(host, port)? 
-        }
-        Some(Either::Right(UrlStdin)) => {
-            let stdin = io::stdin().lock();
-            let stdout = io::stdout().lock();
-            (Box::new(stdin), Box::new(stdout))
-        }
-        None => {
-            connect(Host::Domain("127.0.0.1"), 62185)?
-        }
-    };
+                connect(host, port)?
+            }
+            Some(Either::Right(UrlStdin)) => {
+                let stdin = io::stdin().lock();
+                let stdout = io::stdout().lock();
+                (Box::new(stdin), Box::new(stdout))
+            }
+            None => connect(Host::Domain("127.0.0.1"), 62185)?,
+        };
 
     let chosen = session.get_mechname();
     // Print the selected mechanism as the first output
     println!("{}", chosen.as_str());
-    tx
-        .write_all(chosen.as_bytes())
+    tx.write_all(chosen.as_bytes())
         .into_diagnostic()
         .wrap_err("failed to write to stream")?;
-    tx
-        .write_all(b"\n")
+    tx.write_all(b"\n")
         .into_diagnostic()
         .wrap_err("failed to write to stream")?;
 
@@ -205,8 +207,7 @@ pub fn main() -> miette::Result<()> {
         println!();
         // Then we wait on the first line sent by the server.
         let mut line = String::new();
-        rx
-            .read_line(&mut line)
+        rx.read_line(&mut line)
             .into_diagnostic()
             .wrap_err("failed to read line from stdin")?;
         Some(line)
@@ -227,8 +228,7 @@ pub fn main() -> miette::Result<()> {
         state.is_running()
     } {
         let mut line = String::new();
-        rx
-            .read_line(&mut line)
+        rx.read_line(&mut line)
             .into_diagnostic()
             .wrap_err("failed to read line from stdin")?;
         input = Some(line);

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ trait ConfigInstance: fmt::Debug + Send + Sync {
     fn select(
         &self,
         cb: bool,
-        offered: &mut dyn Iterator<Item=&Mechname>,
+        offered: &mut dyn Iterator<Item = &Mechname>,
     ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError>;
 }
 
@@ -58,7 +58,7 @@ mod provider {
         /// Select the best mechanism of the offered ones.
         pub(crate) fn select_mechanism<'a>(
             &self,
-            offered: impl IntoIterator<Item=&'a Mechname>,
+            offered: impl IntoIterator<Item = &'a Mechname>,
         ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError> {
             let cb = self.get_callback().enable_channel_binding();
             self.inner.select(cb, &mut offered.into_iter())
@@ -74,7 +74,7 @@ mod provider {
 impl SASLConfig {
     #[inline(always)]
     #[allow(dead_code)]
-    pub(crate) fn mech_list<'a>(&self) -> impl Iterator<Item=&'a Mechanism> {
+    pub(crate) fn mech_list<'a>(&self) -> impl Iterator<Item = &'a Mechanism> {
         self.inner.get_mech_iter()
     }
 }
@@ -185,7 +185,10 @@ mod instance {
 
     #[allow(clippy::unnecessary_wraps)]
     #[cfg(any(feature = "config_builder", feature = "testutils"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "config_builder", feature = "testutils"))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "config_builder", feature = "testutils")))
+    )]
     impl Inner {
         pub(crate) fn new<CB: SessionCallback + 'static>(
             callback: CB,
@@ -211,7 +214,7 @@ mod instance {
         fn select(
             &self,
             cb: bool,
-            offered: &mut dyn Iterator<Item=&Mechname>,
+            offered: &mut dyn Iterator<Item = &Mechname>,
         ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError> {
             let callback = self.get_callback();
             self.mechanisms.select(cb | self.cb, offered, |acc, mech| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use core::fmt;
 
 #[doc(inline)]
 #[cfg(feature = "config_builder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config_builder")))]
 pub use crate::builder::ConfigBuilder;
 use crate::mechanism::Authentication;
 use crate::mechname::Mechname;
@@ -18,7 +19,7 @@ trait ConfigInstance: fmt::Debug + Send + Sync {
     fn select(
         &self,
         cb: bool,
-        offered: &mut dyn Iterator<Item = &Mechname>,
+        offered: &mut dyn Iterator<Item=&Mechname>,
     ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError>;
 }
 
@@ -45,6 +46,7 @@ impl fmt::Debug for SASLConfig {
 }
 
 #[cfg(any(test, feature = "provider", feature = "testutils"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "provider", feature = "testutils"))))]
 mod provider {
     use super::{Mechanism, SASLConfig, SASLError, SessionCallback};
     use crate::alloc::boxed::Box;
@@ -56,7 +58,7 @@ mod provider {
         /// Select the best mechanism of the offered ones.
         pub(crate) fn select_mechanism<'a>(
             &self,
-            offered: impl IntoIterator<Item = &'a Mechname>,
+            offered: impl IntoIterator<Item=&'a Mechname>,
         ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError> {
             let cb = self.get_callback().enable_channel_binding();
             self.inner.select(cb, &mut offered.into_iter())
@@ -72,12 +74,13 @@ mod provider {
 impl SASLConfig {
     #[inline(always)]
     #[allow(dead_code)]
-    pub(crate) fn mech_list<'a>(&self) -> impl Iterator<Item = &'a Mechanism> {
+    pub(crate) fn mech_list<'a>(&self) -> impl Iterator<Item=&'a Mechanism> {
         self.inner.get_mech_iter()
     }
 }
 
 #[cfg(feature = "config_builder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config_builder")))]
 mod instance {
     use super::{ConfigInstance, Mechanism, MechanismIter, SASLConfig, SASLError, SessionCallback};
     use crate::alloc::{boxed::Box, string::String, sync::Arc};
@@ -182,6 +185,7 @@ mod instance {
 
     #[allow(clippy::unnecessary_wraps)]
     #[cfg(any(feature = "config_builder", feature = "testutils"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "config_builder", feature = "testutils"))))]
     impl Inner {
         pub(crate) fn new<CB: SessionCallback + 'static>(
             callback: CB,
@@ -207,7 +211,7 @@ mod instance {
         fn select(
             &self,
             cb: bool,
-            offered: &mut dyn Iterator<Item = &Mechname>,
+            offered: &mut dyn Iterator<Item=&Mechname>,
         ) -> Result<(Box<dyn Authentication>, &'static Mechanism), SASLError> {
             let callback = self.get_callback();
             self.mechanisms.select(cb | self.cb, offered, |acc, mech| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,11 +22,13 @@ pub enum MechanismErrorKind {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 /// Errors specific to a certain mechanism
 pub trait MechanismError: fmt::Debug + fmt::Display + Send + Sync + std::error::Error {
     fn kind(&self) -> MechanismErrorKind;
 }
 #[cfg(not(feature = "std"))]
+#[cfg_attr(docsrs, doc(cfg(not(feature = "std"))))]
 /// Errors specific to a certain mechanism
 pub trait MechanismError: fmt::Debug + fmt::Display + Send + Sync {
     fn kind(&self) -> MechanismErrorKind;
@@ -45,6 +47,7 @@ pub enum SessionError {
     },
 
     #[cfg(feature = "provider_base64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "provider_base64")))]
     #[error("base64 wrapping failed")]
     Base64 {
         #[from]
@@ -82,6 +85,7 @@ pub enum SessionError {
 
     #[error(transparent)]
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Boxed(#[from] Box<dyn std::error::Error + Send + Sync>),
 
     #[error("callback did not validate the authentication exchange")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,7 @@
     clippy::missing_errors_doc,
     clippy::box_default
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // FIXME: problems with `registry_static::MECHANISMS` and `linkme::distributed_slice`
 #![allow(clippy::exhaustive_enums)]
 // Mark rsasl `no_std` if the `std` feature flag is not enabled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,14 @@ extern crate std as alloc;
 
 // none of these should be necessary for a provider to compile
 #[cfg(feature = "config_builder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config_builder")))]
 mod builder;
 pub mod callback;
 pub mod mechanisms;
 
 // Only relevant to a provider
 #[cfg(any(feature = "provider", feature = "testutils", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "provider", feature = "testutils"))))]
 mod sasl;
 
 pub mod config;
@@ -304,8 +306,10 @@ mod mechanism;
 mod registry;
 
 #[cfg(any(doc, feature = "unstable_custom_mechanism"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_custom_mechanism")))]
 pub mod mechanism;
 #[cfg(any(doc, feature = "unstable_custom_mechanism"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_custom_mechanism")))]
 pub mod registry;
 
 mod channel_bindings;
@@ -325,10 +329,13 @@ pub mod prelude {
     pub use crate::validate::Validation;
 
     #[cfg(feature = "provider")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "provider")))]
     pub use crate::channel_bindings::ChannelBindingCallback;
     #[cfg(feature = "provider")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "provider")))]
     pub use crate::sasl::{SASLClient, SASLServer};
     #[cfg(feature = "provider")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "provider")))]
     pub use crate::session::Session;
 }
 
@@ -364,6 +371,7 @@ pub mod docs {
     }
 
     #[cfg(feature = "document-features")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "document-features")))]
     pub mod features {
         //! primer on the use of cargo features in rsasl
         //!

--- a/src/mechanisms/anonymous/mechinfo.rs
+++ b/src/mechanisms/anonymous/mechinfo.rs
@@ -28,6 +28,7 @@ impl Property<'_> for AnonymousToken {
 use crate::registry::{distributed_slice, MECHANISMS};
 
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 pub static ANONYMOUS: Mechanism = Mechanism {
     mechanism: Mechname::const_new(b"ANONYMOUS"),
     priority: 100,

--- a/src/mechanisms/external/mechinfo.rs
+++ b/src/mechanisms/external/mechinfo.rs
@@ -7,6 +7,7 @@ use crate::session::Side;
 #[cfg(feature = "registry_static")]
 use crate::registry::{distributed_slice, MECHANISMS};
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 pub static EXTERNAL: Mechanism = Mechanism {
     mechanism: Mechname::const_new(b"EXTERNAL"),
     priority: 100,

--- a/src/mechanisms/gssapi/mechinfo.rs
+++ b/src/mechanisms/gssapi/mechinfo.rs
@@ -8,6 +8,7 @@ use crate::registry::{distributed_slice, MECHANISMS};
 use super::{client, server};
 
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 /// Mechanism description for GSSAPI
 ///
 /// See the [`gssapi`](super) module documentation for details and usage.

--- a/src/mechanisms/login/mechinfo.rs
+++ b/src/mechanisms/login/mechinfo.rs
@@ -8,6 +8,7 @@ use super::{client, server};
 #[cfg(feature = "registry_static")]
 use crate::registry::{distributed_slice, MECHANISMS};
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 pub static LOGIN: Mechanism = Mechanism {
     mechanism: Mechname::const_new(b"LOGIN"),
     priority: 200,

--- a/src/mechanisms/mod.rs
+++ b/src/mechanisms/mod.rs
@@ -25,6 +25,7 @@
 //! to not compile in mechanisms that aren't needed.
 
 #[cfg(feature = "anonymous")]
+#[cfg_attr(docsrs, doc(cfg(feature = "anonymous")))]
 pub mod anonymous {
     //! `ANONYMOUS` *mechanism. Requires feature `anonymous`*
     //!
@@ -42,6 +43,7 @@ pub mod anonymous {
 }
 
 #[cfg(feature = "external")]
+#[cfg_attr(docsrs, doc(cfg(feature = "external")))]
 pub mod external {
     //! `EXTERNAL` *mechanism. Requires feature `external`*
     //!
@@ -58,6 +60,7 @@ pub mod external {
 }
 
 #[cfg(feature = "login")]
+#[cfg_attr(docsrs, doc(cfg(feature = "login")))]
 pub mod login {
     //! `LOGIN` *mechanism. Requires feature `login`*
     //!
@@ -72,6 +75,7 @@ pub mod login {
 }
 
 #[cfg(feature = "plain")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plain")))]
 pub mod plain {
     //! `PLAIN` *mechanism. Requires feature `plain`*
     //!
@@ -112,6 +116,10 @@ pub mod plain {
 }
 
 #[cfg(any(feature = "scram-sha-1", feature = "scram-sha-2"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "scram-sha-1", feature = "scram-sha-2")))
+)]
 pub mod scram {
     //! `SCRAM-*` *mechanisms. Requires feature `scram-sha-1` (for* `-SHA1` *) and/or
     //! `scram-sha-2` (for* `-SHA256` *)*
@@ -147,6 +155,7 @@ pub mod scram {
 }
 
 #[cfg(feature = "xoauth2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "xoauth2")))]
 pub mod xoauth2 {
     //! `XOAUTH2` *mechanism. Requires feature `xoauth2`*
     //!
@@ -170,6 +179,7 @@ pub mod xoauth2 {
 }
 
 #[cfg(feature = "oauthbearer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "oauthbearer")))]
 pub mod oauthbearer {
     //! `OAUTHBEARER` *mechanism. Requires feature `oauthbearer`*
     //!
@@ -198,6 +208,7 @@ pub mod oauthbearer {
 }
 
 #[cfg(feature = "gssapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gssapi")))]
 pub mod gssapi {
     //! `GSSAPI` *mechanism. Requires feature `gssapi`*
     //!

--- a/src/mechanisms/oauthbearer/mechinfo.rs
+++ b/src/mechanisms/oauthbearer/mechinfo.rs
@@ -8,6 +8,7 @@ use crate::registry::{distributed_slice, MECHANISMS};
 use super::{client, server};
 
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 /// Mechanism description for OAUTHBEARER
 ///
 /// See the [`oauthbearer`](super) module documentation for details and usage.

--- a/src/mechanisms/plain/mechinfo.rs
+++ b/src/mechanisms/plain/mechinfo.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 #[cfg(feature = "registry_static")]
 use crate::registry::{distributed_slice, MECHANISMS};
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 /// Mechanism description for PLAIN
 ///
 /// See the [`plain`](super) module documentation for details and usage.

--- a/src/mechanisms/scram/client.rs
+++ b/src/mechanisms/scram/client.rs
@@ -21,11 +21,14 @@ use rand::Rng;
 use thiserror::Error;
 
 #[cfg(feature = "scram-sha-2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-2")))]
 pub type ScramSha256Client<const N: usize> = ScramClient<sha2::Sha256, N>;
 // #[cfg(feature = "scram-sha-2")]
+// #[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-2")))]
 // pub type ScramSha512Client<const N: usize> = ScramClient<sha2::Sha512, N>;
 
 #[cfg(feature = "scram-sha-1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-1")))]
 pub type ScramSha1Client<const N: usize> = ScramClient<sha1::Sha1, N>;
 
 enum CbSupport {

--- a/src/mechanisms/scram/mechinfo.rs
+++ b/src/mechanisms/scram/mechinfo.rs
@@ -18,7 +18,6 @@ mod scram_sha1 {
     #[cfg(feature = "registry_static")]
     use crate::registry::{distributed_slice, MECHANISMS};
     #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
-    #[cfg(feature = "scram-sha-1")]
     pub static SCRAM_SHA1: Mechanism = Mechanism {
         mechanism: Mechname::const_new(b"SCRAM-SHA-1"),
         priority: 400,

--- a/src/mechanisms/scram/mechinfo.rs
+++ b/src/mechanisms/scram/mechinfo.rs
@@ -49,11 +49,11 @@ mod scram_sha1 {
 
     #[derive(Copy, Clone, Debug)]
     enum ScramSelector1 {
-        /// No SCRAM-SHA1 found yet
+        /// No SCRAM-SHA-1 found yet
         No,
-        /// Only SCRAM-SHA1 but not -PLUS found
+        /// Only SCRAM-SHA-1 but not -PLUS found
         Bare,
-        /// SCRAM-SHA1-PLUS found.
+        /// SCRAM-SHA-1-PLUS found.
         Plus,
     }
     impl Selector for ScramSelector1 {

--- a/src/mechanisms/scram/mechinfo.rs
+++ b/src/mechanisms/scram/mechinfo.rs
@@ -18,6 +18,7 @@ mod scram_sha1 {
     #[cfg(feature = "registry_static")]
     use crate::registry::{distributed_slice, MECHANISMS};
     #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
     pub static SCRAM_SHA1: Mechanism = Mechanism {
         mechanism: Mechname::const_new(b"SCRAM-SHA-1"),
         priority: 400,
@@ -108,6 +109,7 @@ mod scram_sha1 {
     }
 }
 #[cfg(feature = "scram-sha-1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-1")))]
 pub use scram_sha1::*;
 
 #[cfg(feature = "scram-sha-2")]
@@ -120,6 +122,7 @@ mod scram_sha256 {
     #[cfg(feature = "registry_static")]
     use crate::registry::{distributed_slice, MECHANISMS};
     #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
     pub static SCRAM_SHA256: Mechanism = Mechanism {
         mechanism: Mechname::const_new(b"SCRAM-SHA-256"),
         priority: 600,
@@ -212,6 +215,7 @@ mod scram_sha256 {
     }
 }
 #[cfg(feature = "scram-sha-2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-2")))]
 pub use scram_sha256::*;
 
 #[cfg(test)]

--- a/src/mechanisms/scram/server.rs
+++ b/src/mechanisms/scram/server.rs
@@ -38,10 +38,13 @@ const DEFAULT_ITERATIONS: &[u8] = b"16384"; // 2u32.pow(14) TODO check if still 
 const DEFAULT_SALT_LEN: usize = 32;
 
 #[cfg(feature = "scram-sha-1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-1")))]
 pub type ScramSha1Server<const N: usize> = ScramServer<sha1::Sha1, N>;
 #[cfg(feature = "scram-sha-2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-2")))]
 pub type ScramSha256Server<const N: usize> = ScramServer<sha2::Sha256, N>;
 // #[cfg(feature = "scram-sha-2")]
+// #[cfg_attr(docsrs, doc(cfg(feature = "scram-sha-2")))]
 // pub type ScramSha512Server<const N: usize> = ScramServer<sha2::Sha512, N>;
 
 #[derive(Debug, Error)]

--- a/src/mechanisms/xoauth2/mechinfo.rs
+++ b/src/mechanisms/xoauth2/mechinfo.rs
@@ -8,6 +8,7 @@ use crate::registry::{distributed_slice, MECHANISMS};
 use super::{client, server};
 
 #[cfg_attr(feature = "registry_static", distributed_slice(MECHANISMS))]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 /// Mechanism description for PLAIN
 ///
 /// See the [`plain`](super) module documentation for details and usage.

--- a/src/mechname.rs
+++ b/src/mechname.rs
@@ -69,6 +69,7 @@ impl Mechname {
 }
 
 #[cfg(feature = "unstable_custom_mechanism")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_custom_mechanism")))]
 /// These associated functions are only available with feature `unstable_custom_mechanism`. They
 /// are *not guaranteed to be stable under semver*
 impl Mechname {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -34,6 +34,7 @@ use crate::config::SASLConfig;
 use crate::error::SASLError;
 pub use crate::session::Side;
 #[cfg(feature = "registry_static")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 pub use registry_static::*;
 
 pub type StartFn = fn() -> Result<Box<dyn Authentication>, SASLError>;
@@ -66,6 +67,7 @@ pub struct Mechanism {
 }
 
 #[cfg(feature = "unstable_custom_mechanism")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable_custom_mechanism")))]
 impl Mechanism {
     /// Construct a Mechanism constant for custom mechanisms
     ///
@@ -136,11 +138,16 @@ pub struct Registry {
 }
 
 #[cfg(any(test, feature = "config_builder", feature = "testutils"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "config_builder", feature = "testutils")))
+)]
 mod config {
     use super::Registry;
     use crate::registry::Mechanism;
 
     #[cfg(feature = "config_builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "config_builder")))]
     impl Registry {
         #[inline(always)]
         #[must_use]
@@ -179,6 +186,7 @@ mod config {
     }
 
     #[cfg(feature = "registry_static")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
     impl Default for Registry {
         fn default() -> Self {
             Self::with_mechanisms(&super::registry_static::MECHANISMS)
@@ -261,6 +269,7 @@ impl Registry {
 }
 
 #[cfg(feature = "registry_static")]
+#[cfg_attr(docsrs, doc(cfg(feature = "registry_static")))]
 mod registry_static {
     use super::Mechanism;
     pub use linkme::distributed_slice;

--- a/src/sasl.rs
+++ b/src/sasl.rs
@@ -39,6 +39,7 @@ impl<V: Validation + Debug, CB: Debug> Debug for Sasl<V, CB> {
 }
 
 #[cfg(any(feature = "provider", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "provider")))]
 #[allow(dead_code)]
 mod provider {
     use super::{

--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,7 @@ pub enum Side {
 }
 
 #[cfg(any(feature = "provider", feature = "testutils", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "provider", feature = "testutils"))))]
 mod provider {
     use super::{
         ChannelBindingCallback, Mechanism, MechanismData, SessionCallback, SessionData,
@@ -214,6 +215,7 @@ mod provider {
     }
 
     #[cfg(feature = "provider_base64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "provider_base64")))]
     impl<V: Validation, C: ChannelBindingCallback> Session<V, C> {
         /// Perform one step of SASL authentication, base64 encoded.
         ///
@@ -299,6 +301,7 @@ mod provider {
     }
 }
 #[cfg(any(feature = "provider", feature = "testutils", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "provider", feature = "testutils"))))]
 pub use provider::Session;
 
 pub struct MechanismData<'a> {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -129,6 +129,7 @@ impl Validation for NoValidation {
 /// mechanism.
 pub struct Validate<'a>(dyn Erased<'a> + 'a);
 #[cfg(any(test, feature = "provider", feature = "testutils"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "provider", feature = "testutils"))))]
 impl Validate<'_> {
     pub(crate) fn new<'opt, V: Validation>(opt: &'opt mut Tagged<'_, V>) -> &'opt mut Self {
         unsafe { &mut *(opt as &mut dyn Erased as *mut dyn Erased as *mut Self) }


### PR DESCRIPTION
This closes #8.

To test locally:

```sh
RUSTFLAGS="--cfg docsrs" RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features --open
```

Note: I didn't remove the prose hints for now. If this is the right direction, I could make another commit. This is also all a bit repetitive and I might missed a few instances. Unfortunately, I have no better idea how to archive something similar automatically.