### PR TITLE
chore: Silence/Resolve Clippy lints + reformat + CI work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,15 +100,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.61.0
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Install required packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libgssapi-krb5-2 libkrb5-dev
       - name: Check
         run: |
           cargo +nightly update -Z minimal-versions
-          cargo +1.61 check --workspace --all-targets --all-features
-          cargo +1.61 test --workspace --all-targets --all-features
+          cargo +1.61.0 check --workspace --all-targets --all-features
+          cargo +1.61.0 test --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install required packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libgssapi-krb5-2 libkrb5-dev
-      - run: cargo test --all
+      - run: cargo test --workspace
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
@@ -78,7 +78,7 @@ jobs:
       - name: Install required packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libgssapi-krb5-2 libkrb5-dev
-      - run: cargo miri test --all --all-features
+      - run: cargo miri test --workspace --all-features
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,11 @@ jobs:
       - name: Install required packages (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install libgssapi-krb5-2 libkrb5-dev
-      - run: cargo test --workspace
+      - run: |
+          # Note: `--workspace` may pull in features.
+          # However, we also want `cargo test` (w/o features) to work.
+          cargo test
+          cargo test --workspace
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 

--- a/bin/interop-client/src/main.rs
+++ b/bin/interop-client/src/main.rs
@@ -117,14 +117,17 @@ impl TypedValueParser for UrlParser {
     }
 }
 
-fn connect<S: AsRef<str>>(host: url::Host<S>, port: u16) -> miette::Result<(Box<dyn io::BufRead>, Box<dyn io::Write>)> {
+fn connect<S: AsRef<str>>(
+    host: url::Host<S>,
+    port: u16,
+) -> miette::Result<(Box<dyn io::BufRead>, Box<dyn io::Write>)> {
     let stream = match host {
         Host::Ipv4(ip) => TcpStream::connect((ip, port)),
         Host::Ipv6(ip) => TcpStream::connect((ip, port)),
         Host::Domain(ref domain) => TcpStream::connect((domain.as_ref(), port)),
     }
-        .into_diagnostic()
-        .wrap_err(format!("failed to connect to {}:{}", host, port))?;
+    .into_diagnostic()
+    .wrap_err(format!("failed to connect to {}:{}", host, port))?;
 
     let write_end = stream
         .try_clone()
@@ -169,32 +172,31 @@ pub fn main() -> miette::Result<()> {
         .into_diagnostic()
         .wrap_err("Failed to start client session")?;
 
-    let (mut rx, mut tx): (Box<dyn io::BufRead>, Box<dyn io::Write>) = match matches.get_one::<Either<url::Url, UrlStdin>>("listen") {
-        Some(Either::Left(url)) => { 
-            let host = url.host().ok_or_else(|| miette!("URL must have a host part"))?;
-            let port = url.port().unwrap_or(62185);
+    let (mut rx, mut tx): (Box<dyn io::BufRead>, Box<dyn io::Write>) =
+        match matches.get_one::<Either<url::Url, UrlStdin>>("listen") {
+            Some(Either::Left(url)) => {
+                let host = url
+                    .host()
+                    .ok_or_else(|| miette!("URL must have a host part"))?;
+                let port = url.port().unwrap_or(62185);
 
-            connect(host, port)? 
-        }
-        Some(Either::Right(UrlStdin)) => {
-            let stdin = io::stdin().lock();
-            let stdout = io::stdout().lock();
-            (Box::new(stdin), Box::new(stdout))
-        }
-        None => {
-            connect(Host::Domain("127.0.0.1"), 62185)?
-        }
-    };
+                connect(host, port)?
+            }
+            Some(Either::Right(UrlStdin)) => {
+                let stdin = io::stdin().lock();
+                let stdout = io::stdout().lock();
+                (Box::new(stdin), Box::new(stdout))
+            }
+            None => connect(Host::Domain("127.0.0.1"), 62185)?,
+        };
 
     let chosen = session.get_mechname();
     // Print the selected mechanism as the first output
     println!("{}", chosen.as_str());
-    tx
-        .write_all(chosen.as_bytes())
+    tx.write_all(chosen.as_bytes())
         .into_diagnostic()
         .wrap_err("failed to write to stream")?;
-    tx
-        .write_all(b"\n")
+    tx.write_all(b"\n")
         .into_diagnostic()
         .wrap_err("failed to write to stream")?;
 
@@ -205,8 +207,7 @@ pub fn main() -> miette::Result<()> {
         println!();
         // Then we wait on the first line sent by the server.
         let mut line = String::new();
-        rx
-            .read_line(&mut line)
+        rx.read_line(&mut line)
             .into_diagnostic()
             .wrap_err("failed to read line from stdin")?;
         Some(line)
@@ -227,8 +228,7 @@ pub fn main() -> miette::Result<()> {
         state.is_running()
     } {
         let mut line = String::new();
-        rx
-            .read_line(&mut line)
+        rx.read_line(&mut line)
             .into_diagnostic()
             .wrap_err("failed to read line from stdin")?;
         input = Some(line);

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,7 @@ mod instance {
         mechanisms: Registry,
     }
 
+    #[allow(clippy::missing_fields_in_debug)]
     impl fmt::Debug for Inner {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("SASLConfig")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@
 //! # fn get_more_auth_data() -> Option<Vec<u8>> { unimplemented!() }
 //! // the `config` is provided by the user of this crate. The `writer` is a stand-in for sending
 //! // data to other side of the authentication exchange.
+//! // Note: The "provider" feature is required.
+//! #[cfg(feature = "provider")]
 //! fn sasl_authenticate(config: Arc<SASLConfig>, writer: &mut impl io::Write) {
 //!     let sasl = SASLClient::new(config);
 //!     // These would normally be provided via the protocol in question

--- a/src/mechanisms/anonymous/server.rs
+++ b/src/mechanisms/anonymous/server.rs
@@ -81,12 +81,14 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn test_reject_invalid_1() {
         test_token("token", b"");
     }
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn test_reject_invalid_2() {
         test_token("", b"someunexpectedtoken");
     }

--- a/src/mechanisms/external/server.rs
+++ b/src/mechanisms/external/server.rs
@@ -87,12 +87,14 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn test_reject_invalid_1() {
         test_token("expectedauthzid", b"");
     }
 
     #[test]
     #[should_panic]
+    #[allow(clippy::should_panic_without_expect)]
     fn test_reject_invalid_2() {
         test_token("", b"someunexpectedauthzid");
     }

--- a/src/mechanisms/scram/tools.rs
+++ b/src/mechanisms/scram/tools.rs
@@ -23,6 +23,7 @@ where
     pbkdf2::pbkdf2::<SimpleHmac<D>>(password, salt, iterations, out.as_mut_slice());
 }
 
+#[allow(clippy::missing_panics_doc)]
 #[allow(clippy::too_many_arguments)]
 pub fn compute_signatures<D: Digest + BlockSizeUser + FixedOutput>(
     stored_key: &GenericArray<u8, D::OutputSize>,
@@ -77,6 +78,7 @@ pub fn compute_signatures<D: Digest + BlockSizeUser + FixedOutput>(
         .finalize_into(server_signature);
 }
 
+#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn derive_keys<D>(password: &[u8]) -> (DOutput<D>, DOutput<D>)
 where

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -110,6 +110,7 @@ impl Mechanism {
     }
 }
 
+#[allow(clippy::missing_fields_in_debug)]
 impl fmt::Debug for Mechanism {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Mechanism")

--- a/src/test/config.rs
+++ b/src/test/config.rs
@@ -34,11 +34,13 @@ impl SessionCallback for EmptyCallback {}
 
 static MECHANISMS: [Mechanism; 2] = [RSASLTEST_CF, RSASLTEST_SF];
 
+#[allow(clippy::missing_panics_doc)]
 pub fn client_config<CB: SessionCallback + 'static>(cb: CB) -> Arc<SASLConfig> {
     SASLConfig::new(cb, Registry::with_mechanisms(&MECHANISMS))
         .expect("Failed to generate known-good sasl config")
 }
 
+#[allow(clippy::missing_panics_doc)]
 pub fn server_config<CB: SessionCallback + 'static>(cb: CB) -> Arc<SASLConfig> {
     SASLConfig::new(cb, Registry::with_mechanisms(&MECHANISMS))
         .expect("Failed to generate known-good sasl config")

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -32,6 +32,8 @@
 //!     type Value = MyDataType;
 //! }
 //!
+//! // Note: The "provider" feature is required.
+//! #[cfg(feature = "provider")]
 //! fn do_auth(config: Arc<SASLConfig>, selected: &Mechname) {
 //!     let sasl = SASLServer::<MyValidation>::new(config);
 //!

--- a/src/vectored_io.rs
+++ b/src/vectored_io.rs
@@ -30,7 +30,7 @@ impl<'io, const N: usize> VectoredWriter<'io, N> {
         let mut remove = 0;
         // Total length of all the to be removed buffers.
         let mut accumulated_len = 0;
-        for buf in self.data[self.skip..].iter() {
+        for buf in &self.data[self.skip..] {
             if accumulated_len + buf.len() > len {
                 break;
             }


### PR DESCRIPTION
This makes rustfmt and Clippy happy. I believe that the added `allow`s are apppropriate. But better to be careful :-)

Also, I'm trying to resolve a few CI issues: Here, we need to agree how to resolve the dependency issues (explained below).

Further, `cargo test` (w/o) `--workspace` failed but CI was happy. This is, I believe, because `--workspace` pulls in additional dependencies. Thus, the examples in the doc failed because `provider` is not a default feature. And in CI, we always test with `--workspace`. [cargo-hack](https://github.com/taiki-e/cargo-hack) is maybe worth a try.