### PR TITLE
Enrich `gssapi::Error` with message from `libgssapi::error::Error`

### DIFF
--- a/src/mechanisms/gssapi/properties.rs
+++ b/src/mechanisms/gssapi/properties.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("GSS-API error")]
+    #[error("GSS-API error: {0}")]
     Gss(
         #[source]
         #[from]


### PR DESCRIPTION
```
GSS-API error: Miscellaneous failure (see text) (Error from KDC: UNKNOWN_SERVER while looking up 'zookeeper2/10.0.0.129@0.0.129' (cached result, timeout in 1184 sec) (negative cache))
```

Comparing to simple `GSS-API error`.