### PR TITLE
feat: support `SCRAM-SHA-512` and `SCRAM-SHA-512-PLUS` 

### DIFF
--- a/src/mechanisms/scram/client.rs
+++ b/src/mechanisms/scram/client.rs
@@ -23,8 +23,8 @@ use thiserror::Error;
 
 #[cfg(feature = "scram-sha-2")]
 pub type ScramSha256Client<const N: usize> = ScramClient<sha2::Sha256, N>;
-// #[cfg(feature = "scram-sha-2")]
-// pub type ScramSha512Client<const N: usize> = ScramClient<sha2::Sha512, N>;
+#[cfg(feature = "scram-sha-2")]
+pub type ScramSha512Client<const N: usize> = ScramClient<sha2::Sha512, N>;
 
 #[cfg(feature = "scram-sha-1")]
 pub type ScramSha1Client<const N: usize> = ScramClient<sha1::Sha1, N>;

--- a/src/mechanisms/scram/server.rs
+++ b/src/mechanisms/scram/server.rs
@@ -42,8 +42,8 @@ const DEFAULT_SALT_LEN: usize = 32;
 pub type ScramSha1Server<const N: usize> = ScramServer<sha1::Sha1, N>;
 #[cfg(feature = "scram-sha-2")]
 pub type ScramSha256Server<const N: usize> = ScramServer<sha2::Sha256, N>;
-// #[cfg(feature = "scram-sha-2")]
-// pub type ScramSha512Server<const N: usize> = ScramServer<sha2::Sha512, N>;
+#[cfg(feature = "scram-sha-2")]
+pub type ScramSha512Server<const N: usize> = ScramServer<sha2::Sha512, N>;
 
 #[derive(Debug, Error)]
 pub enum ScramServerError {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -155,6 +155,8 @@ mod config {
         pub(crate) fn credentials(authzid: bool) -> Self {
             static CRED_AUTHZID: &[Mechanism] = &[
                 #[cfg(feature = "scram-sha-2")]
+                crate::mechanisms::scram::SCRAM_SHA512,
+                #[cfg(feature = "scram-sha-2")]
                 crate::mechanisms::scram::SCRAM_SHA256,
                 #[cfg(feature = "scram-sha-1")]
                 crate::mechanisms::scram::SCRAM_SHA1,
@@ -163,6 +165,8 @@ mod config {
             ];
 
             static CRED: &[Mechanism] = &[
+                #[cfg(feature = "scram-sha-2")]
+                crate::mechanisms::scram::SCRAM_SHA512,
                 #[cfg(feature = "scram-sha-2")]
                 crate::mechanisms::scram::SCRAM_SHA256,
                 #[cfg(feature = "scram-sha-1")]
@@ -190,6 +194,8 @@ mod config {
     impl Default for Registry {
         fn default() -> Self {
             static BUILTIN: &[Mechanism] = &[
+                #[cfg(feature = "scram-sha-2")]
+                crate::mechanisms::scram::SCRAM_SHA512,
                 #[cfg(feature = "scram-sha-2")]
                 crate::mechanisms::scram::SCRAM_SHA256,
                 #[cfg(feature = "scram-sha-1")]


### PR DESCRIPTION
Add support for `SCRAM-SHA-512` and `SCRAM-SHA-512-PLUS`. Tested with Kafka.

See also: #26, https://github.com/influxdata/rskafka/pull/247