### PR TITLE
Export types for unstable_custom_mechanism feature

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -23,6 +23,7 @@ pub trait ProviderExt<'a>: Provider<'a> {
 }
 impl<'a, P: Provider<'a>> ProviderExt<'a> for P {}
 
+#[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
 pub struct EmptyProvider;
 impl Provider<'_> for EmptyProvider {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,10 @@
 //! define a [`Mechanism`](registry::Mechanism) struct describing the implemented mechanism.
 //! Documentation about how to add a custom mechanism is found in the [`registry module documentation`](registry).
 
+// `missing_const_for_fn` warns functions with parameter types having no const constructor.
+//
+// See also https://github.com/rust-lang/rust-clippy/issues/8021
+#![allow(clippy::missing_const_for_fn)]
 // Mark rsasl `no_std` if the `std` feature flag is not enabled.
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #[cfg(not(any(feature = "std", test)))]

--- a/src/mechanism.rs
+++ b/src/mechanism.rs
@@ -4,6 +4,10 @@
 use crate::error::SessionError::NoSecurityLayer;
 use core2::io::Write;
 
+#[cfg(any(doc, feature = "unstable_custom_mechanism"))]
+pub use crate::context::{Demand, DemandReply, EmptyProvider, Provider, ProviderExt, ThisProvider};
+#[cfg(any(doc, feature = "unstable_custom_mechanism"))]
+pub use crate::error::MechanismErrorKind;
 #[allow(unused_imports)]
 pub use crate::error::{MechanismError, SessionError};
 pub use crate::session::{MechanismData, State};

--- a/src/mechanisms/scram/parser.rs
+++ b/src/mechanisms/scram/parser.rs
@@ -108,7 +108,7 @@ impl<'a> SaslName<'a> {
             return Err(SaslNameError::InvalidChar(0));
         }
 
-        if input.contains(|c| matches!(c, ',' | '=')) {
+        if input.contains([',', '=']) {
             let escaped: String = input.chars().flat_map(SaslEscapeState::escape).collect();
             Ok(Cow::Owned(escaped))
         } else {
@@ -120,7 +120,7 @@ impl<'a> SaslName<'a> {
     /// Convert a SCRAM-side string into the representation expected by Rust
     ///
     /// This will clone the given string if characters need unescaping
-    pub fn unescape(input: &'a [u8]) -> Result<Cow<'_, str>, SaslNameError> {
+    pub fn unescape(input: &[u8]) -> Result<Cow<'_, str>, SaslNameError> {
         if input.is_empty() {
             return Err(SaslNameError::Empty);
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -270,9 +270,14 @@ impl Registry {
 #[cfg(feature = "registry_static")]
 mod registry_static {
     use super::Mechanism;
+    /// Reexport from [`linkme`](https://docs.rs/linkme).
+    ///
+    /// **Please add compatible `linkme` version to your `Cargo.toml`.** Currently, there is no way
+    /// to export public dependency. See [Tracking issue for RFC 1977: public & private dependencies](https://github.com/rust-lang/rust/issues/44663).
+    pub use linkme::distributed_slice;
 
     //noinspection RsTypeCheck
-    #[linkme::distributed_slice]
+    #[distributed_slice]
     pub static MECHANISMS: [Mechanism];
 }
 #[cfg(not(feature = "registry_static"))]


### PR DESCRIPTION
`2.1.0` does not export assistant types for type [`MechanismData`](https://docs.rs/rsasl/2.1.0/rsasl/mechanism/struct.MechanismData.html) and [MechanismError](https://docs.rs/rsasl/2.1.0/rsasl/mechanism/trait.MechanismError.html).